### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/Templates/security/code-scanning/1](https://github.com/BoBoBaSs84/Templates/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root, right after the `on:` section (or after `name:`), so it applies to all jobs unless overridden.  
For this workflow, the best minimal permission is:

- `contents: read`

This preserves current functionality (checkout + build/test) while enforcing least privilege for `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
